### PR TITLE
Remove pull warning msg + keeps default strategy

### DIFF
--- a/scripts/hack
+++ b/scripts/hack
@@ -12,6 +12,6 @@ else
 	master_branch="master"
 fi
 git checkout ${master_branch}
-git pull origin ${master_branch} --tags
+git pull origin ${master_branch} --no-rebase --tags
 git checkout ${CURRENT}
 git rebase ${master_branch}


### PR DESCRIPTION
Remove the "Pulling without specifying how to reconcile divergent branche" warning message.
Keeps the default no-rebase strategy